### PR TITLE
Updated format regex for converting old placeholder syntax to macros

### DIFF
--- a/src/XperienceCommunity.FormNotifications/Services/FormNotificationEmailService.cs
+++ b/src/XperienceCommunity.FormNotifications/Services/FormNotificationEmailService.cs
@@ -206,7 +206,7 @@ namespace XperienceCommunity.FormNotifications.Services
         private string ResolveMacros(MacroResolver macroResolver, string content)
         {
             // Include support for anyone copying form placeholders from previous environments by changing $$label:FieldName$$ and $$value:FieldName$$ to {% label_FieldName %} and {% value_FieldName %}
-            var oldFormatRegex = new Regex("\\$\\$(value|label):([a-zA-Z_][a-zA-Z0-9_]+)\\$\\$");
+            var oldFormatRegex = new Regex("\\$\\$(value|label):([a-zA-Z_]+[a-zA-Z0-9_]*)\\$\\$");
             content = oldFormatRegex.Replace(content ?? "", "{% $1_$2 %}");
             return macroResolver.ResolveMacros(content ?? "", null);
         }

--- a/src/XperienceCommunity.FormNotifications/Services/FormNotificationEmailService.cs
+++ b/src/XperienceCommunity.FormNotifications/Services/FormNotificationEmailService.cs
@@ -206,7 +206,7 @@ namespace XperienceCommunity.FormNotifications.Services
         private string ResolveMacros(MacroResolver macroResolver, string content)
         {
             // Include support for anyone copying form placeholders from previous environments by changing $$label:FieldName$$ and $$value:FieldName$$ to {% label_FieldName %} and {% value_FieldName %}
-            var oldFormatRegex = new Regex("\\$\\$(value|label):([a-zA-Z0-9]+)\\$\\$");
+            var oldFormatRegex = new Regex("\\$\\$(value|label):([a-zA-Z_][a-zA-Z0-9_]+)\\$\\$");
             content = oldFormatRegex.Replace(content ?? "", "{% $1_$2 %}");
             return macroResolver.ResolveMacros(content ?? "", null);
         }


### PR DESCRIPTION
As stated in #2, the regex should also allow underscores and the first character must be a letter or an underscore